### PR TITLE
Inference in SSM

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -34,6 +34,8 @@ end
 
 abstract type AbstractCortexModel end
 
+Base.broadcastable(m::AbstractCortexModel) = Ref(m)
+
 struct FactorId{T}
     id::T
 end

--- a/test/inference_tests.jl
+++ b/test/inference_tests.jl
@@ -222,40 +222,41 @@ end
             add_edge_to_model!(model, oi, fi)
         end
 
+        resolve_dependencies!(model, BeliefPropagation())
+
         return model, p, o, f
     end
 
-    function experiment(n, dataset)
-        model, p, o, f = make_beta_bernoulli_model(n)
+    function computer(model::Model, signal::Cortex.Signal, dependencies::Vector{Cortex.Signal})
+        if signal.type == Cortex.InferenceSignalTypes.MessageToVariable
+            v, f = signal.metadata
 
-        resolve_dependencies!(model, BeliefPropagation())
+            factor = get_factor_data(model.graph, f)
+
+            if factor.type === Bernoulli
+                r = Cortex.get_value(dependencies[1])::Bool
+                return Beta(one(r) + r, 2one(r) - r)
+            elseif factor.type === :prior
+                error("Should not be invoked")
+            end
+        elseif signal.type == Cortex.InferenceSignalTypes.IndividualMarginal
+            answer = Cortex.get_value(dependencies[1])::Beta
+            for i in 2:length(dependencies)
+                @inbounds next = Cortex.get_value(dependencies[i])::Beta
+                answer = Beta(answer.a + next.a - 1, answer.b + next.b - 1)
+            end
+            return answer
+        end
+
+        error("Unreachable reached")
+    end
+
+    function experiment(dataset)
+        n = length(dataset)
+        model, p, o, f = make_beta_bernoulli_model(n)
 
         for i in 1:n
             Cortex.set_value!(Cortex.get_edge_message_to_factor(model, o[i], f[i]), dataset[i])
-        end
-
-        function computer(model::Model, signal::Cortex.Signal, dependencies::Vector{Cortex.Signal})
-            if signal.type == Cortex.InferenceSignalTypes.MessageToVariable
-                v, f = signal.metadata
-
-                factor = get_factor_data(model.graph, f)
-
-                if factor.type === Bernoulli
-                    r = Cortex.get_value(dependencies[1])::Bool
-                    return Beta(one(r) + r, 2one(r) - r)
-                elseif factor.type === :prior
-                    error("Should not be invoked")
-                end
-            elseif signal.type == Cortex.InferenceSignalTypes.IndividualMarginal
-                answer = Cortex.get_value(dependencies[1])::Beta
-                for i in 2:length(dependencies)
-                    @inbounds next = Cortex.get_value(dependencies[i])::Beta
-                    answer = Beta(answer.a + next.a - 1, answer.b + next.b - 1)
-                end
-                return answer
-            end
-
-            error("Unreachable reached")
         end
 
         Cortex.update_posterior!(computer, model, p)
@@ -267,7 +268,7 @@ end
     rng = StableRNG(1234)
     dataset = rand(rng, Bool, n)
 
-    answer = experiment(n, dataset)
+    answer = experiment(dataset)
 
     # Known answer calculation for Beta-Bernoulli
     # Prior: Beta(1, 1)
@@ -280,4 +281,89 @@ end
 
     @test answer.a ≈ known_answer.a
     @test answer.b ≈ known_answer.b
+end
+
+@testitem "Inference in a simple SSM model" setup = [ModelUtils] begin
+    using .ModelUtils
+    using JET, BipartiteFactorGraphs, StableRNGs
+
+    struct Normal
+        mean::Float64
+        variance::Float64
+    end
+
+    # In this model, we assume that both the likelihood and the transition are Normal
+    # with fixed variance equal to 1.0.
+    function make_ssm_model(n)
+        model = Model()
+
+        x = [add_variable_to_model!(model, :x, i) for i in 1:n]
+        y = [add_variable_to_model!(model, :y, i) for i in 1:n]
+
+        likelihood = [add_factor_to_model!(model, :likelihood) for i in 1:n]
+        transition = [add_factor_to_model!(model, :transition) for i in 1:(n - 1)]
+
+        for i in 1:n
+            add_edge_to_model!(model, y[i], likelihood[i])
+            add_edge_to_model!(model, x[i], likelihood[i])
+        end
+
+        for i in 1:(n - 1)
+            add_edge_to_model!(model, x[i], transition[i])
+            add_edge_to_model!(model, x[i + 1], transition[i])
+        end
+
+        resolve_dependencies!(model, BeliefPropagation())
+
+        return model, x, y, likelihood, transition
+    end
+
+    function product(left::Normal, right::Normal)
+        xi = left.mean / left.variance + right.mean / right.variance
+        w = 1 / left.variance + 1 / right.variance
+        variance = 1 / w
+        mean = variance * xi
+        return Normal(mean, variance)
+    end
+
+    function computer(model::Model, signal::Cortex.Signal, dependencies::Vector{Cortex.Signal})
+        if signal.type == Cortex.InferenceSignalTypes.IndividualMarginal
+            return reduce(product, Cortex.get_value.(dependencies))
+        elseif signal.type == Cortex.InferenceSignalTypes.MessageToFactor
+            return reduce(product, Cortex.get_value.(dependencies))
+        elseif signal.type == Cortex.InferenceSignalTypes.MessageToVariable
+            @assert length(dependencies) == 1
+            input = Cortex.get_value(dependencies[1])
+
+            if typeof(input) <: Real
+                return Normal(input, 1.0)
+            elseif typeof(input) <: Normal
+                return Normal(input.mean, input.variance + 1.0)
+            else
+                error("Unreachable reached")
+            end
+        end
+
+        error("Unreachable reached")
+    end
+
+    function experiment(dataset)
+        n = length(dataset)
+        model, x, y, likelihood, transition = make_ssm_model(n)
+
+        for i in 1:n
+            Cortex.set_value!(Cortex.get_edge_message_to_factor(model, y[i], likelihood[i]), dataset[i])
+        end
+
+        Cortex.update_posterior!(computer, model, x)
+
+        return Cortex.get_value.(Cortex.get_variable_marginal.(model, x))
+    end
+
+    rng = StableRNG(1234)
+    dataset = rand(rng, 100)
+
+    answer = experiment(dataset)
+
+    
 end

--- a/test/model_tests.jl
+++ b/test/model_tests.jl
@@ -112,9 +112,8 @@ end
         index::Any
         marginal::Signal
 
-        Variable(name, index...) = new(
-            name, index, Signal(type = Cortex.InferenceSignalTypes.IndividualMarginal, metadata = (name, index...))
-        )
+        Variable(name, index...) =
+            new(name, index, Signal(type = Cortex.InferenceSignalTypes.IndividualMarginal, metadata = (name, index...)))
     end
 
     function Cortex.add_variable_to_model!(model::Model, name::Any, index...)
@@ -201,6 +200,27 @@ end
             Cortex.add_dependency!(
                 Cortex.get_variable_marginal(model, VariableId(vi)), paired_messages[1].to_variable; intermediate = true
             )
+            return nothing
+        end
+
+        # Use a simplified approach for small numbers of neighbors
+        if N <= 5
+            for i in 1:N
+                Cortex.add_dependency!(
+                    Cortex.get_variable_marginal(model, VariableId(vi)),
+                    paired_messages[i].to_variable;
+                    intermediate = true
+                )
+
+                for k in 1:N
+                    if i !== k
+                        Cortex.add_dependency!(
+                            paired_messages[i].to_factor, paired_messages[k].to_variable; intermediate = true
+                        )
+                    end
+                end
+            end
+
             return nothing
         end
 

--- a/test/signal_tests.jl
+++ b/test/signal_tests.jl
@@ -1186,3 +1186,35 @@ end
         @test at_least_one_dependency_processed
     end
 end
+
+@testitem "`process_dependencies!` should be type-stable" begin
+    import Cortex: Signal, add_dependency!, process_dependencies!
+    import JET
+
+    source = Signal()
+    intermediate = Signal()
+    derived = Signal()
+
+    add_dependency!(intermediate, source)
+    add_dependency!(derived, intermediate; intermediate = true)
+
+    JET.@test_opt process_dependencies!(derived; retry = true) do dependency
+        return dependency === source
+    end
+
+    JET.@test_opt process_dependencies!(derived; retry = true) do dependency
+        return true
+    end
+
+    JET.@test_opt process_dependencies!(derived; retry = true) do dependency
+        return false
+    end
+
+    JET.@test_opt process_dependencies!(derived; retry = false) do dependency
+        return true
+    end
+
+    JET.@test_opt process_dependencies!(derived; retry = false) do dependency
+        return false
+    end
+end

--- a/test/signal_tests.jl
+++ b/test/signal_tests.jl
@@ -1,3 +1,287 @@
+
+@testitem "Signal Dependencies Properties Basic Operations" begin
+    import Cortex: SignalDependenciesProps, SignalDependenciesProps
+
+    props = SignalDependenciesProps()
+
+    @test props.ndependencies == 0
+
+    Cortex.add_dependency!(props)
+
+    @test props.ndependencies == 1
+
+    @test Cortex.is_dependency_weak(props, 1) == false
+    @test Cortex.is_dependency_intermediate(props, 1) == false
+    @test Cortex.is_dependency_computed(props, 1) == false
+    @test Cortex.is_dependency_fresh(props, 1) == false
+
+    # we do this 4 times to make sure that repetative calls to the same function
+    # do not change the result
+
+    for i in 1:4
+        Cortex.set_dependency_weak!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == true
+        @test Cortex.is_dependency_intermediate(props, 1) == false
+        @test Cortex.is_dependency_computed(props, 1) == false
+        @test Cortex.is_dependency_fresh(props, 1) == false
+    end
+
+    for i in 1:4
+        Cortex.set_dependency_intermediate!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == true
+        @test Cortex.is_dependency_intermediate(props, 1) == true
+        @test Cortex.is_dependency_computed(props, 1) == false
+        @test Cortex.is_dependency_fresh(props, 1) == false
+    end
+
+    for i in 1:4
+        Cortex.set_dependency_computed!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == true
+        @test Cortex.is_dependency_intermediate(props, 1) == true
+        @test Cortex.is_dependency_computed(props, 1) == true
+        @test Cortex.is_dependency_fresh(props, 1) == false
+    end
+
+    for i in 1:4
+        Cortex.set_dependency_fresh!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == true
+        @test Cortex.is_dependency_intermediate(props, 1) == true
+        @test Cortex.is_dependency_computed(props, 1) == true
+        @test Cortex.is_dependency_fresh(props, 1) == true
+    end
+
+    for i in 1:4
+        Cortex.unset_dependency_weak!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == false
+        @test Cortex.is_dependency_intermediate(props, 1) == true
+        @test Cortex.is_dependency_computed(props, 1) == true
+        @test Cortex.is_dependency_fresh(props, 1) == true
+    end
+
+    for i in 1:4
+        Cortex.unset_dependency_intermediate!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == false
+        @test Cortex.is_dependency_intermediate(props, 1) == false
+        @test Cortex.is_dependency_computed(props, 1) == true
+        @test Cortex.is_dependency_fresh(props, 1) == true
+    end
+
+    for i in 1:4
+        Cortex.unset_dependency_computed!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == false
+        @test Cortex.is_dependency_intermediate(props, 1) == false
+        @test Cortex.is_dependency_computed(props, 1) == false
+        @test Cortex.is_dependency_fresh(props, 1) == true
+    end
+
+    for i in 1:4
+        Cortex.unset_dependency_fresh!(props, 1)
+        @test Cortex.is_dependency_weak(props, 1) == false
+        @test Cortex.is_dependency_intermediate(props, 1) == false
+        @test Cortex.is_dependency_computed(props, 1) == false
+        @test Cortex.is_dependency_fresh(props, 1) == false
+    end
+end
+
+@testitem "Signal Dependencies Properties Basic Operations with Many Dependencies" begin
+    import Cortex: SignalDependenciesProps, SignalDependenciesProps
+
+    n = 100
+
+    for k in 1:n
+        props = SignalDependenciesProps()
+
+        @test props.ndependencies == 0
+
+        for i in 1:n
+            Cortex.add_dependency!(props)
+        end
+
+        @test props.ndependencies == n
+
+        for i in 1:n
+            @test !Cortex.is_dependency_weak(props, i)
+            @test !Cortex.is_dependency_intermediate(props, i)
+            @test !Cortex.is_dependency_computed(props, i)
+            @test !Cortex.is_dependency_fresh(props, i)
+        end
+
+        Cortex.set_dependency_weak!(props, k)
+
+        for i in 1:n
+            @test Cortex.is_dependency_weak(props, i) == (i == k)
+        end
+
+        Cortex.set_dependency_intermediate!(props, k)
+
+        for i in 1:n
+            @test Cortex.is_dependency_weak(props, i) == (i == k)
+            @test Cortex.is_dependency_intermediate(props, i) == (i == k)
+        end
+
+        Cortex.set_dependency_computed!(props, k)
+
+        for i in 1:n
+            @test Cortex.is_dependency_weak(props, i) == (i == k)
+            @test Cortex.is_dependency_intermediate(props, i) == (i == k)
+            @test Cortex.is_dependency_computed(props, i) == (i == k)
+        end
+
+        Cortex.set_dependency_fresh!(props, k)
+
+        for i in 1:n
+            @test Cortex.is_dependency_weak(props, i) == (i == k)
+            @test Cortex.is_dependency_intermediate(props, i) == (i == k)
+            @test Cortex.is_dependency_computed(props, i) == (i == k)
+            @test Cortex.is_dependency_fresh(props, i) == (i == k)
+        end
+
+        Cortex.unset_dependency_weak!(props, k)
+
+        for i in 1:n
+            @test !Cortex.is_dependency_weak(props, i)
+            @test Cortex.is_dependency_intermediate(props, i) == (i == k)
+            @test Cortex.is_dependency_computed(props, i) == (i == k)
+            @test Cortex.is_dependency_fresh(props, i) == (i == k)
+        end
+
+        Cortex.unset_dependency_intermediate!(props, k)
+
+        for i in 1:n
+            @test !Cortex.is_dependency_weak(props, i)
+            @test !Cortex.is_dependency_intermediate(props, i)
+            @test Cortex.is_dependency_computed(props, i) == (i == k)
+            @test Cortex.is_dependency_fresh(props, i) == (i == k)
+        end
+
+        Cortex.unset_dependency_computed!(props, k)
+
+        for i in 1:n
+            @test !Cortex.is_dependency_weak(props, i)
+            @test !Cortex.is_dependency_intermediate(props, i)
+            @test !Cortex.is_dependency_computed(props, i)
+            @test Cortex.is_dependency_fresh(props, i) == (i == k)
+        end
+
+        Cortex.unset_dependency_fresh!(props, k)
+
+        for i in 1:n
+            @test !Cortex.is_dependency_weak(props, i)
+            @test !Cortex.is_dependency_intermediate(props, i)
+            @test !Cortex.is_dependency_computed(props, i)
+            @test !Cortex.is_dependency_fresh(props, i)
+        end
+    end
+end
+
+@testitem "Signal Dependencies Properties Unset All Fresh" begin
+    import Cortex: SignalDependenciesProps, SignalDependenciesProps
+
+    props = SignalDependenciesProps()
+
+    n = 100
+
+    for i in 1:n
+        Cortex.add_dependency!(props)
+    end
+
+    for i in 1:n
+        for i in 1:4
+            for k in 1:i
+                Cortex.set_dependency_fresh!(props, k)
+            end
+
+            for j in 1:n
+                @test Cortex.is_dependency_fresh(props, j) == (j <= i)
+            end
+        end
+
+        for i in 1:4
+            Cortex.unset_all_fresh!(props)
+
+            for j in 1:n
+                @test !Cortex.is_dependency_fresh(props, j)
+            end
+        end
+    end
+end
+
+@testitem "Signal Dependencies Properties is_pending #1" begin
+    import Cortex: SignalDependenciesProps
+
+    @testset for ndependencies in 1:100
+        props = SignalDependenciesProps()
+
+        for i in 1:ndependencies
+            Cortex.add_dependency!(props)
+        end
+
+        # In the beginning, the props cannot be pending
+        @test !Cortex.is_pending(props)
+
+        # If we set all dependencies to computed, the props should not be pending
+        # as it also requires all dependencies to be fresh
+        for i in 1:ndependencies
+            Cortex.set_dependency_computed!(props, i)
+            @test !Cortex.is_pending(props)
+        end
+
+        @test !Cortex.is_pending(props)
+
+        # If we set all dependencies to fresh, the props should be pending
+        for i in 1:ndependencies
+            Cortex.set_dependency_fresh!(props, i)
+            if i < ndependencies
+                # If we have not set all dependencies to fresh, the props should not be pending
+                @test !Cortex.is_pending(props)
+            else
+                # If we have set all dependencies to fresh AND computed, the props should be pending
+                @test Cortex.is_pending(props)
+            end
+        end
+    end
+end
+
+@testitem "Signal Dependencies Properties is_pending #2" begin
+    import Cortex: SignalDependenciesProps
+
+    @testset for ndependencies in 1:100
+        props = SignalDependenciesProps()
+
+        for i in 1:ndependencies
+            Cortex.add_dependency!(props)
+        end
+
+        # In the beginning, the props cannot be pending
+        @test !Cortex.is_pending(props)
+
+        # If we set all dependencies to computed, the props should not be pending
+        # the dependencies can either be weak or fresh
+        for i in 1:ndependencies
+            Cortex.set_dependency_computed!(props, i)
+            @test !Cortex.is_pending(props)
+        end
+
+        @test !Cortex.is_pending(props)
+
+        # If we set all dependencies to fresh, the props should be pending
+        for i in 1:ndependencies
+            if div(i, 2) == 0
+                Cortex.set_dependency_weak!(props, i)
+            else
+                Cortex.set_dependency_fresh!(props, i)
+            end
+            if i < ndependencies
+                # If we have not set all dependencies to fresh, the props should not be pending
+                @test !Cortex.is_pending(props)
+            else
+                # If we have set all dependencies to fresh AND computed, the props should be pending
+                @test Cortex.is_pending(props)
+            end
+        end
+    end
+end
+
 @testitem "Basic Signal Operations" begin
     import Cortex: Signal, set_value!, get_value
 


### PR DESCRIPTION
This PR prepares preliminary infrastructure for running inference in SSM. Additionally it refactors the implementation of Signals for maximum performance in terms of checking the status of the dependencies of a particular signal. This is achieved in `SignalDependenciesProps` that packs the status of all dependencies in a binary format and allows efficient queries on the entire array of dependencies. Previously the code needed to iterate over all dependencies, which made it particularly slow on memory accesses. 

In my private benchmarks, I pushed inference time in simple SSM models by a factor of ~7 and memory by a factor of ~5. 
For IID models similar in terms of time, but memory is reduced only by a factor of ~2.